### PR TITLE
Whitelisted Channels: Add global option, fix parsing

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,6 +9,6 @@
     "GITHUB_API_TOKEN": "YOUR_GITHUB_API_TOKEN",
     "GITHUB_FILE_PATH": "<username>/<repo>/contents/<path_to_project.json>/project.json",
     "GITHUB_ADDRESS_FILE_PATH": "<username>/<repo>/contents/<path_to_addressbook.json>/addressbook.json",
-    "WHITELISTED_CHANNELS": "channel1,channel2,etc"
+    "WHITELISTED_CHANNELS": "*"
   }
 }

--- a/src/environment.js
+++ b/src/environment.js
@@ -1,5 +1,48 @@
-module.exports = {
-  environment(name) {
-    return process.env[name] || null
-  },
+const { EnvironmentError } = require('./error-utils')
+
+// Structure:
+// [environmentVariable, default, required?]
+const ENV_VARS = {
+  DISCORD_API_TOKEN: [
+    process.env.DISCORD_API_TOKEN,
+    'YOUR_DISCORD_API_TOKEN',
+    true,
+  ],
+  GITHUB_API_TOKEN: [
+    process.env.GITHUB_API_TOKEN,
+    'YOUR_GITHUB_API_TOKEN',
+    true,
+  ],
+  GITHUB_FILE_PATH: [
+    process.env.GITHUB_FILE_PATH,
+    '<username>/<repo>/contents/<path_to_project.json>/project.json',
+    true,
+  ],
+  GITHUB_ADDRESS_FILE_PATH: [
+    process.env.GITHUB_ADDRESS_FILE_PATH,
+    '<username>/<repo>/contents/<path_to_addressbook.json>/addressbook.json',
+    true,
+  ],
+  SENTRY_DSN: [process.env.SENTRY_DSN, '', false],
+  WHITELISTED_CHANNELS: [process.env.WHITELISTED_CHANNELS, '*', false],
 }
+
+function environment(name) {
+  const envVar = ENV_VARS[name]
+  if (!envVar) {
+    return null
+  }
+  // If the environment variable is required and has not been properly set,
+  // throw an error.
+  if (envVar === ENV_VARS[name][1] && ENV_VARS[name][2]) {
+    throw new EnvironmentError(
+      `The environment variable with name ${name} has not been set properly. Please edit it on the heroku config vars.`,
+    )
+  }
+
+  return envVar[0] === undefined ? envVar[1] : envVar[0].trim()
+}
+
+function fullEnvironment() {}
+
+module.exports = { environment, fullEnvironment }

--- a/src/error-utils.js
+++ b/src/error-utils.js
@@ -1,3 +1,10 @@
+class EnvironmentError extends Error {
+  constructor(message) {
+    super(`${Date.now()}: ${message}`)
+    this.name = 'EnvironmentError'
+  }
+}
+
 class RequestHandlerError extends Error {
   constructor(message) {
     super(`${Date.now()}: ${message}`)
@@ -12,4 +19,8 @@ class WhitelistedChannelError extends Error {
   }
 }
 
-module.exports = { RequestHandlerError, WhitelistedChannelError }
+module.exports = {
+  EnvironmentError,
+  RequestHandlerError,
+  WhitelistedChannelError,
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const detectHandler = require('./parser/detectHandler')
 const {
   RequestHandlerError,
   WhitelistedChannelError,
-} = require('./parser/error-utils')
+} = require('./error-utils')
 const { environment } = require('./environment')
 const { error, log } = require('./utils')
 const parseWhitelistedChannels = require('./parser/whitelistedChannels')
@@ -28,7 +28,8 @@ client.on('message', message => {
     const whitelistedChannels = parseWhitelistedChannels()
 
     const messageWhitelisted = whitelistedChannels.reduce(
-      (whitelisted, channel) => channel === message.channel.name || whitelisted,
+      (whitelisted, channel) =>
+        channel === message.channel.name || channel === '*' || whitelisted,
       false,
     )
 

--- a/src/parser/detectHandler.js
+++ b/src/parser/detectHandler.js
@@ -1,4 +1,4 @@
-const { RequestHandlerError } = require('./error-utils')
+const { RequestHandlerError } = require('../error-utils')
 const handlers = require('../handlers/index')
 
 const noop = () => undefined

--- a/src/parser/whitelistedChannels.js
+++ b/src/parser/whitelistedChannels.js
@@ -3,7 +3,7 @@ const { environment } = require('../environment')
 module.exports = function parseWhitelistedChannels() {
   const channels = environment('WHITELISTED_CHANNELS')
   if (!channels) {
-    return ''
+    return ['*']
   }
 
   return channels.split(',')


### PR DESCRIPTION
This PR adds a "global" option for the bot to listen to all channels. The only step needed to use it, is set the `WHITELISTED_CHANNELS` variable to `"*"` on the `.env` file locally, or `*` on the config vars on heroku (note the lack of double quotes). Also fixes the parsing of these channels to handle empty cases.